### PR TITLE
add Mockito's "when" support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # knit [![Circle CI](https://circleci.com/gh/ntaro/knit/tree/master.svg?style=shield)](https://circleci.com/gh/ntaro/knit/tree/master) [ ![Download](https://api.bintray.com/packages/ngsw-taro/maven/knit/images/download.svg) ](https://bintray.com/ngsw-taro/maven/knit/_latestVersion)
 
-JUnit API set for Kotlin.
+JUnit and Mockito API set for Kotlin.
 
 ```kotlin
 class UnitTest {
     @Test
     fun test() {
-        (1 + 2).should be 3  // assertThat(1 + 2, `is`(3))
+        (1 + 2).should be 3            // assertThat(1 + 2, `is`(3))
+        module.hello() returns "Hello" // when(module.hello()).thenReturn("Hello")
     }
 }
 ```

--- a/build.gradle
+++ b/build.gradle
@@ -56,4 +56,5 @@ repositories {
 dependencies {
     compile "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     compile 'junit:junit:4.12'
+    compile 'org.mockito:mockito-core:1.9.5'
 }

--- a/src/main/kotlin/com/taroid/knit/extensions.kt
+++ b/src/main/kotlin/com/taroid/knit/extensions.kt
@@ -2,6 +2,8 @@ package com.taroid.knit
 
 import org.hamcrest.Matcher
 import org.junit.Assert
+import org.mockito.Mockito.`when`
+import org.mockito.stubbing.OngoingStubbing
 
 val <T> T.should: Asserter<T>
     get() = AsserterFactory.newInstance(this)
@@ -12,3 +14,16 @@ val <T> (() -> T).should: Asserter<T>
 fun <T> T.should(matcher: Matcher<in T>) {
     Assert.assertThat(this, matcher)
 }
+
+infix fun <T> T.returns(value: T) = `when`(this).thenReturn(value)
+
+fun <T> T.returns(value: T, vararg values: T) = `when`(this).thenReturn(value, *values)
+
+infix fun <T> OngoingStubbing<T>.nextReturns(value: T) = this.thenReturn(value)
+
+infix fun <T> T.throws(throwable: Throwable) = `when`(this).thenThrow(throwable)
+
+fun <T> T.throws(throwable: Throwable, vararg throwables: Throwable) =
+        `when`(this).thenThrow(throwable, *throwables)
+
+infix fun <T> OngoingStubbing<T>.nextThrows(throwable: Throwable) = this.thenThrow(throwable)

--- a/src/test/kotlin/com/taroid/knit/ExtensionsKtTest.kt
+++ b/src/test/kotlin/com/taroid/knit/ExtensionsKtTest.kt
@@ -6,6 +6,7 @@ import org.junit.Assert.assertThat
 import org.junit.Test
 import org.junit.experimental.runners.Enclosed
 import org.junit.runner.RunWith
+import org.mockito.Mockito
 
 @RunWith(Enclosed::class)
 class ExtensionsKtTest {
@@ -33,6 +34,93 @@ class ExtensionsKtTest {
 
             assertThat(got.javaClass, `is`(sameInstance(expected.javaClass)))
             assertThat(got.target, `is`(sameInstance(expected.target)))
+        }
+    }
+
+    class `returns - value` {
+
+        @Test
+        fun `return the expected value when mocked function is called`() {
+            @Suppress("UNCHECKED_CAST")
+            val mockAsserter = Mockito.mock(Asserter::class.java) as Asserter<String?>
+
+            mockAsserter.target returns null
+            assertThat(mockAsserter.target, `is`(null as String?))
+
+            mockAsserter.target returns "Kotlin"
+            assertThat(mockAsserter.target, `is`("Kotlin"))
+        }
+    }
+
+    class `returns - values` {
+
+        @Test
+        fun `return the expected values when mocked function is called`() {
+            @Suppress("UNCHECKED_CAST")
+            val mockAsserter = Mockito.mock(Asserter::class.java) as Asserter<String?>
+
+            mockAsserter.target.returns(null, "Kotlin")
+            assertThat(mockAsserter.target, `is`(null as String?))
+            assertThat(mockAsserter.target, `is`("Kotlin"))
+        }
+    }
+
+    class `nextReturns - value` {
+
+        @Test
+        fun `return the expected value when mocked function is called for the second time`() {
+            @Suppress("UNCHECKED_CAST")
+            val mockAsserter = Mockito.mock(Asserter::class.java) as Asserter<String?>
+
+            mockAsserter.target returns null nextReturns "Kotlin"
+            assertThat(mockAsserter.target, `is`(null as String?))
+            assertThat(mockAsserter.target, `is`("Kotlin"))
+        }
+    }
+
+    class `throws - throwable` {
+
+        @Test(expected = NullPointerException::class)
+        fun `throws error when mocked function is called`() {
+            @Suppress("UNCHECKED_CAST")
+            val mockAsserter = Mockito.mock(Asserter::class.java) as Asserter<String?>
+
+            mockAsserter.target throws NullPointerException()
+            mockAsserter.target
+        }
+    }
+
+    class `throws - throwables` {
+
+        @Test(expected = UnsupportedOperationException::class)
+        fun `throws errors when mocked function is called`() {
+            @Suppress("UNCHECKED_CAST")
+            val mockAsserter = Mockito.mock(Asserter::class.java) as Asserter<String?>
+
+            mockAsserter.target.throws(NullPointerException(), UnsupportedOperationException())
+            try {
+                mockAsserter.target
+            } catch (e: NullPointerException) {
+                // Nothing to do.
+            }
+            mockAsserter.target
+        }
+    }
+
+    class `nextThrows - throwable` {
+
+        @Test(expected = UnsupportedOperationException::class)
+        fun `throws error when mocked function is called`() {
+            @Suppress("UNCHECKED_CAST")
+            val mockAsserter = Mockito.mock(Asserter::class.java) as Asserter<String?>
+
+            mockAsserter.target throws NullPointerException() nextThrows UnsupportedOperationException()
+            try {
+                mockAsserter.target
+            } catch (e: NullPointerException) {
+                // Nothing to do.
+            }
+            mockAsserter.target
         }
     }
 }


### PR DESCRIPTION
`Mockito.when` is also ugly in Kotlin since we should write as ``when``.
This patch solves the issue.
